### PR TITLE
feat: MySQL 연결, Content entity 생성

### DIFF
--- a/src/main/java/ku/cse/team11/RankHub/domain/Content.java
+++ b/src/main/java/ku/cse/team11/RankHub/domain/Content.java
@@ -1,0 +1,72 @@
+package ku.cse.team11.RankHub.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Content {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 기본 정보
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String author;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ContentType type;
+
+    @Column(length = 2000)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Platform platform;
+
+    private String thumbnailUrl;
+
+    @Column(nullable = false)
+    private String contentUrl;
+
+    private LocalDate publishDate;      // 연재 시작일
+
+    private Integer episodeCount;
+
+    @Enumerated(EnumType.STRING)
+    private ContentStatus contentStatus;
+
+    // 초기만 문자열
+    private String tags;
+
+    private String genre;
+
+    private String ageRating;
+
+    private String updateFrequency;
+
+    // 통계
+    private Long views = 0L;
+
+    private Double rating = 0.0;
+
+    private Long likes = 0L;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/ku/cse/team11/RankHub/domain/ContentStatus.java
+++ b/src/main/java/ku/cse/team11/RankHub/domain/ContentStatus.java
@@ -1,0 +1,5 @@
+package ku.cse.team11.RankHub.domain;
+
+public enum ContentStatus {
+    ONGOING, COMPLETED, HIATUS, UPCOMING
+}

--- a/src/main/java/ku/cse/team11/RankHub/domain/ContentType.java
+++ b/src/main/java/ku/cse/team11/RankHub/domain/ContentType.java
@@ -1,0 +1,5 @@
+package ku.cse.team11.RankHub.domain;
+
+public enum ContentType {
+    WEBTOON, WEBNOVEL
+}

--- a/src/main/java/ku/cse/team11/RankHub/domain/Platform.java
+++ b/src/main/java/ku/cse/team11/RankHub/domain/Platform.java
@@ -1,0 +1,5 @@
+package ku.cse.team11.RankHub.domain;
+
+public enum Platform {
+    NAVER_WEBTOON, KAKAO_PAGE, KAKAO_WEBTOON, SERIES, NOVELPIA, MUNPIA
+}

--- a/src/main/java/ku/cse/team11/RankHub/repository/ContentRepository.java
+++ b/src/main/java/ku/cse/team11/RankHub/repository/ContentRepository.java
@@ -1,0 +1,7 @@
+package ku.cse.team11.RankHub.repository;
+
+import ku.cse.team11.RankHub.domain.Content;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContentRepository extends JpaRepository<Content, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=RankHub

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/rankhub_db?serverTimezone=Asia/Seoul
+    username: root
+    password: root
+
+  jpa:
+    hibernate:
+      ddl-auto: update   # 엔티티 기반으로 스키마 자동 반영
+    properties:
+      hibernate:
+        show_sql: true   # 실행된 SQL 콘솔 출력
+        format_sql: true # SQL 보기 좋게 포맷
+    database-platform: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
| 필드명          | 타입                | 설명 |
|-----------------|---------------------|------|
| id              | Long                | 콘텐츠 고유 식별자 |
| title           | String              | 제목 |
| author          | String              | 작가명 |
| type            | ContentType (Enum)  | 콘텐츠 유형 (웹툰/웹소설) |
| description     | String              | 콘텐츠 설명 |
| platform        | Platform (Enum)     | 서비스 플랫폼 |
| thumbnailUrl    | String              | 썸네일 이미지 URL |
| contentUrl      | String              | 원본 콘텐츠 URL (링크) |
| publishDate     | LocalDate           | 연재 시작일 |
| episodeCount    | Integer             | 에피소드/회차 수 |
| contentStatus   | ContentStatus (Enum)| 콘텐츠 상태 (연재중, 완결 등) |
| tags            | String              | 태그 (초기엔 문자열로 관리) |
| genre           | String              | 장르 (초기엔 문자열로 관리) |
| ageRating       | String              | 연령 등급 (초기엔 문자열로 관리) |
| updateFrequency | String              | 업데이트 주기 (초기엔 문자열로 관리) |
| views           | Long                | 조회 수 |
| rating          | Double              | 평균 평점 |
| likes           | Long                | 좋아요 수 |
| createdAt       | LocalDateTime       | 데이터 생성 시각 |
| updatedAt       | LocalDateTime       | 데이터 마지막 수정 시각 |
