### PR TITLE
feat: 랭킹 서비스

### DIFF
--- a/src/main/java/ku/cse/team11/RankHub/controller/RankController.java
+++ b/src/main/java/ku/cse/team11/RankHub/controller/RankController.java
@@ -1,0 +1,47 @@
+package ku.cse.team11.RankHub.controller;
+
+import ku.cse.team11.RankHub.domain.content.ContentType;
+import ku.cse.team11.RankHub.domain.content.Platform;
+import ku.cse.team11.RankHub.domain.rank.RankService;
+import ku.cse.team11.RankHub.dto.auth.RankResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ranks")
+public class RankController {
+
+    private final RankService rankService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshRanks() {
+        rankService.refreshRanks();
+        return ResponseEntity.ok(Map.of("message", "Ranks refreshed successfully"));
+    }
+
+    @GetMapping("/{type}/all")
+    public ResponseEntity<List<RankResponse>> getOverallRanks(
+            @PathVariable("type") ContentType type,
+            @RequestParam(required = false) Integer limit) {
+
+        return ResponseEntity.ok(
+                rankService.getRanks(type, true, null, limit)
+        );
+    }
+
+    @GetMapping("/{type}/platform/{platform}")
+    public ResponseEntity<List<RankResponse>> getPlatformRanks(
+            @PathVariable("type") ContentType type,
+            @PathVariable("platform") Platform platform,
+            @RequestParam(required = false) Integer limit) {
+
+        return ResponseEntity.ok(
+                rankService.getRanks(type, false, platform, limit)
+        );
+    }
+}

--- a/src/main/java/ku/cse/team11/RankHub/domain/content/Content.java
+++ b/src/main/java/ku/cse/team11/RankHub/domain/content/Content.java
@@ -56,8 +56,6 @@ public class Content {
     // 통계
     private Long views = 0L;
 
-    private Double rating = 0.0;
-
     private Long likes = 0L;
 
     @CreationTimestamp

--- a/src/main/java/ku/cse/team11/RankHub/domain/rank/Rank.java
+++ b/src/main/java/ku/cse/team11/RankHub/domain/rank/Rank.java
@@ -1,0 +1,68 @@
+package ku.cse.team11.RankHub.domain.rank;
+
+import jakarta.persistence.*;
+import ku.cse.team11.RankHub.domain.content.Content;
+import ku.cse.team11.RankHub.domain.content.ContentType;
+import ku.cse.team11.RankHub.domain.content.Platform;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Rank {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id", nullable = false, unique = true)
+    private Content content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ContentType contentType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Platform platform;
+
+    // 조회수 랭크
+    private Long views;
+    private Integer viewRank;
+    private Integer platformViewRank;
+
+    // 즐겨찾기 랭크
+    private Long favorites;
+    private Integer favoriteRank;
+
+    // 앱 내 사용자 평가
+    private Long gradeScore;
+    private String gradeRank;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    public Rank(Content content, Long views) {
+        this.content = content;
+        this.views = views;
+        this.contentType = content.getContentType();
+        this.platform = content.getPlatform();
+    }
+
+    public void updateRanks(Integer overallRank, Integer platformRank) {
+        this.viewRank = overallRank;
+        this.platformViewRank = platformRank;
+    }
+
+    public void updateViews(Long views) {
+        this.views = views;
+    }
+}
+

--- a/src/main/java/ku/cse/team11/RankHub/domain/rank/RankRepository.java
+++ b/src/main/java/ku/cse/team11/RankHub/domain/rank/RankRepository.java
@@ -59,7 +59,7 @@ public interface RankRepository extends JpaRepository<Rank, Long> {
                content_type,
                platform,
                CASE
-                   WHEN platform = 'NAVER_WEBTOON' THEN likes * 500
+                   WHEN platform = 'NAVER_WEBTOON' THEN likes * 150
                    ELSE views
                END AS calc_views,
                RANK() OVER (PARTITION BY content_type ORDER BY

--- a/src/main/java/ku/cse/team11/RankHub/domain/rank/RankRepository.java
+++ b/src/main/java/ku/cse/team11/RankHub/domain/rank/RankRepository.java
@@ -1,0 +1,77 @@
+package ku.cse.team11.RankHub.domain.rank;
+
+import ku.cse.team11.RankHub.domain.content.Content;
+import ku.cse.team11.RankHub.domain.content.ContentType;
+import ku.cse.team11.RankHub.domain.content.Platform;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RankRepository extends JpaRepository<Rank, Long> {
+    Optional<Rank> findByContent(Content content);
+
+    /**
+     * 콘텐츠 유형별 랭킹 조회 메서드
+     *
+     * @param type     조회할 콘텐츠 유형
+     * @param pageable 페이징/정렬 정보
+     *                 - Pageable.unpaged(): 전체 결과 조회
+     *                 - PageRequest.of(0, 100): 상위 100개만 조회
+     *
+     * @return 지정된 콘텐츠 유형의 Rank 리스트 (Content 포함 fetch join)
+     *         viewRank 기준 오름차순 정렬
+     */
+    @Query("SELECT r FROM Rank r " +
+            "JOIN FETCH r.content " +
+            "WHERE r.contentType = :type " +
+            "ORDER BY r.viewRank ASC")
+    List<Rank> findByContentType(@Param("type") ContentType type, Pageable pageable);
+
+    /**
+     * 콘텐츠 유형 + 플랫폼별 랭킹 조회 메서드
+     *
+     * @param type     조회할 콘텐츠 유형
+     * @param platform 조회할 플랫폼 유형
+     * @param pageable 페이징/정렬 정보
+     *                 - Pageable.unpaged(): 전체 결과 조회
+     *                 - PageRequest.of(0, 100): 상위 100개만 조회
+     *
+     * @return 지정된 콘텐츠 유형의 Rank 리스트 (Content 포함 fetch join)
+     *         viewRank 기준 오름차순 정렬
+     */
+    @Query("SELECT r FROM Rank r " +
+            "JOIN FETCH r.content " +
+            "WHERE r.contentType = :type " +
+            "AND r.platform = :platform " +
+            "ORDER BY r.platformViewRank ASC")
+    List<Rank> findByContentTypeAndPlatform(
+            @Param("type") ContentType type, @Param("platform") Platform platform, Pageable pageable);
+
+    @Modifying
+    @Query(value = """
+        INSERT INTO rank (content_id, content_type, platform, views, view_rank, platform_view_rank)
+        SELECT id,
+               content_type,
+               platform,
+               CASE
+                   WHEN platform = 'NAVER_WEBTOON' THEN likes * 500
+                   ELSE views
+               END AS calc_views,
+               RANK() OVER (PARTITION BY content_type ORDER BY
+                            CASE WHEN platform = 'NAVER_WEBTOON' THEN likes * 10 ELSE views END DESC),
+               RANK() OVER (PARTITION BY content_type, platform ORDER BY
+                            CASE WHEN platform = 'NAVER_WEBTOON' THEN likes * 10 ELSE views END DESC)
+        FROM content
+        ON CONFLICT (content_id) DO UPDATE
+        SET views = EXCLUDED.views,
+            view_rank = EXCLUDED.view_rank,
+            platform_view_rank = EXCLUDED.platform_view_rank,
+            updated_at = now();
+            """, nativeQuery = true)
+    void refreshViewRanks();
+}

--- a/src/main/java/ku/cse/team11/RankHub/domain/rank/RankService.java
+++ b/src/main/java/ku/cse/team11/RankHub/domain/rank/RankService.java
@@ -1,0 +1,46 @@
+package ku.cse.team11.RankHub.domain.rank;
+
+import ku.cse.team11.RankHub.domain.content.ContentRepository;
+import ku.cse.team11.RankHub.domain.content.ContentType;
+import ku.cse.team11.RankHub.domain.content.Platform;
+import ku.cse.team11.RankHub.dto.auth.RankResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RankService {
+    private final RankRepository rankRepository;
+
+    // Rank 최신화
+    @Transactional
+    public void refreshRanks() {
+        rankRepository.refreshViewRanks(); // 조회수 랭크 최신화
+    }
+
+    @Transactional
+    public List<RankResponse> getRanks(ContentType type, boolean overall, Platform platform, Integer limit) {
+        List<Rank> ranks;
+        if (overall) {
+            ranks = rankRepository.findByContentType(
+                    type,
+                    limit != null ? PageRequest.of(0, limit) : Pageable.unpaged()
+            );
+        } else {
+            ranks = rankRepository.findByContentTypeAndPlatform(
+                    type,
+                    platform,
+                    limit != null ? PageRequest.of(0, limit) : Pageable.unpaged()
+            );
+        }
+
+        return ranks.stream()
+                .map(r -> RankResponse.from(r, overall))
+                .toList();
+    }
+}

--- a/src/main/java/ku/cse/team11/RankHub/dto/auth/ContentDto.java
+++ b/src/main/java/ku/cse/team11/RankHub/dto/auth/ContentDto.java
@@ -1,0 +1,24 @@
+package ku.cse.team11.RankHub.dto.auth;
+
+import ku.cse.team11.RankHub.domain.content.Content;
+import ku.cse.team11.RankHub.domain.rank.Rank;
+
+public record ContentDto(
+        Long id,
+        String title,
+        String authors,
+        String thumbnailUrl,
+        String platform,
+        Long views
+) {
+    public static ContentDto from(Content content, Long views) {
+        return new ContentDto(
+                content.getId(),
+                content.getTitle(),
+                content.getAuthors(),
+                content.getThumbnailUrl(),
+                content.getPlatform().name(),
+                views
+        );
+    }
+}

--- a/src/main/java/ku/cse/team11/RankHub/dto/auth/RankResponse.java
+++ b/src/main/java/ku/cse/team11/RankHub/dto/auth/RankResponse.java
@@ -1,0 +1,15 @@
+package ku.cse.team11.RankHub.dto.auth;
+
+import ku.cse.team11.RankHub.domain.rank.Rank;
+
+public record RankResponse(
+        Integer rank,
+        ContentDto content
+) {
+    public static RankResponse from(Rank rank, boolean overall) {
+        return new RankResponse(
+                overall ? rank.getViewRank() : rank.getPlatformViewRank(),
+                ContentDto.from(rank.getContent(), rank.getViews())
+        );
+    }
+}


### PR DESCRIPTION
### Rank 엔티티 생성
- 원본 데이터(Content)와 따로 관리하기 위해 별도의 엔티티 생성함

컬럼명 | 타입 | 제약조건 | 설명
-- | -- | -- | --
id | BIGINT | PK, Auto Increment | Rank 고유 식별자
content_id | BIGINT | FK(Content.id), NOT NULL, UNIQUE | 콘텐츠 ID (1:1 매핑)
content_type | VARCHAR | NOT NULL | 콘텐츠 유형 (WEBTOON,WEBNOVEL)
platform | VARCHAR | NOT NULL | 플랫폼 (NAVER_WEBTOON, KAKAO_WEBTOON 등)
views | BIGINT |   | 조회수 (네이버 웹툰은 좋아요 1 당 환산)
view_rank | INT |   | 전체 콘텐츠 기준 조회수 순위
platform_view_rank | INT |   | 같은 플랫폼 내 조회수 순위
updated_at | TIMESTAMP | DEFAULT CURRENT_TIMESTAMP | 마지막 갱신 시간

<br>

- 즐겨찾기, 사용자 평가 티어 관련 필드(구현 안함, 안하면 삭제)

컬럼명 | 타입 | 설명
-- | -- | -- 
favorites | BIGINT | 즐겨찾기 수
favorite_rank | INT | 즐겨찾기 기준 순위
grade_score | BIGINT | 사용자 평가 점수 합계
grade_rank | VARCHAR | 사용자 평가 티어

<br>

### 조회수 랭킹 업데이트, 랭킹 조회 기능 구현
- https://www.notion.so/Rank-25c824aac22380b0ac4bee0727866503?source=copy_link
- 조회수 랭킹 Refresh `POST /api/ranks/refresh`
- 전체 조회수 랭킹 조회(limit = 상위 N개) `GET /api/ranks/{type}/all?limit={N}`
- 플랫폼별 조회수 랭킹 조회(limit = 상위 N개) `GET /api/ranks/{type}/platform/{platform}?limit={N}`